### PR TITLE
Prefer peeled hashes for tags

### DIFF
--- a/internal/source/source_test.go
+++ b/internal/source/source_test.go
@@ -117,7 +117,7 @@ func TestSource(t *testing.T) {
 				ScanMatch:  map[string]string{},
 				SourceArgs: map[string]string{},
 			},
-			expectGet: "6f5dc406130fdf939cc0f49fb0a5904b35a3c46f",
+			expectGet: "b0ac3e9413b1079c8b14df5c201a2a2129d9d9e1",
 			expectKey: "git ref",
 		},
 		{


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Hashes for git tags are for the signed/annotated tag itself and not the underlying commit.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

The go-git library added hashes for the peeled commit in their v5.7.0 release. This prefers those hashes when available.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

Getting a version for a git tag will not return the expected hash.
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Switch git tag hashes to the underlying commit hash
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed
