### PR TITLE
Override Go versions for OSV Scanner

### DIFF
--- a/.github/workflows/vulnscans.yml
+++ b/.github/workflows/vulnscans.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  govunlcheck:
-    name: Go Vuln Check
+  vulnerability-scans:
+    name: Run vulnerability scans
     runs-on: ubuntu-latest
     env:
       RELEASE_GO_VER: "1.22"
@@ -22,7 +22,7 @@ jobs:
         go-version: "${{ env.RELEASE_GO_VER }}"
         check-latest: true
 
-    # vulnerability scanners are intentionally not pinned
+    # intentionally not pinned to always run the latest scanner
     - name: "Install govulncheck"
       run: |
         go install golang.org/x/vuln/cmd/govulncheck@latest
@@ -31,10 +31,11 @@ jobs:
       run: |
         govulncheck ./...
 
+    # intentionally not pinned to always run the latest scanner
     - name: "Install OSV Scanner"
       run: |
         go install github.com/google/osv-scanner/cmd/osv-scanner@latest
 
     - name: "Run OSV Scanner"
       run: |
-        osv-scanner -r .
+        osv-scanner scan --config .osv-scanner.toml -r --experimental-licenses="Apache-2.0,BSD-3-Clause,MIT,CC-BY-SA-4.0,UNKNOWN" .

--- a/.osv-scanner.toml
+++ b/.osv-scanner.toml
@@ -1,0 +1,1 @@
+GoVersionOverride = "1.22.2"

--- a/.version-bump.yml
+++ b/.version-bump.yml
@@ -22,6 +22,9 @@ files:
   "go.mod":
     scans:
       - go-mod-golang-release
+  ".osv-scanner.toml":
+    scans:
+      - osv-golang-release
 
 scans:
   docker-arg-alpine-tag:
@@ -108,6 +111,12 @@ scans:
     args:
       regexp: '^STATICCHECK_VER\?=(?P<Version>v[0-9\.]+)\s*$'
       repo: "github.com/dominikh/go-tools"
+  osv-golang-release:
+    type: "regexp"
+    source: "registry-tag-arg-semver"
+    args:
+      regexp: '^GoVersionOverride = "(?P<Version>[0-9\.]+)"\s*$'
+      repo: "docker.io/library/golang"
 
 sources:
   gha-uses-vx:

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ vulnerability-scan: osv-scanner vulncheck-go ## Run all vulnerability scanners
 
 .PHONY: osv-scanner
 osv-scanner: $(GOPATH)/bin/osv-scanner .FORCE ## Run OSV Scanner
-	$(GOPATH)/bin/osv-scanner scan -r .
+	$(GOPATH)/bin/osv-scanner scan --config .osv-scanner.toml -r --experimental-licenses="Apache-2.0,BSD-2-Clause,BSD-3-Clause,ISC,MqIT,CC-BY-SA-4.0,UNKNOWN" .
 
 .PHONY: vulncheck-go
 vulncheck-go: $(GOPATH)/bin/govulncheck .FORCE ## Run govulncheck


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This avoids OSV Scanner failing for older versions of Go supported by the go.mod (to allow the project to be used as a library).
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make osv-scanner
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Update osv-scanner configuration to use current Go release.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
