### PR TITLE
Chore: Fix Dockerfile linter warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 ARG GO_VER=1.22.5-alpine@sha256:0d3653dd6f35159ec6e3d10263a42372f6f194c3dea0b35235d72aabde86486e
 
-FROM ${REGISTRY}/library/golang:${GO_VER} as build
+FROM ${REGISTRY}/library/golang:${GO_VER} AS build
 RUN apk add --no-cache \
       ca-certificates \
       make
@@ -13,10 +13,10 @@ RUN make bin/version-bump
 USER appuser
 CMD [ "bin/version-bump" ]
 
-FROM scratch as artifact
+FROM scratch AS artifact
 COPY --from=build /src/bin/version-bump /version-bump
 
-FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
+FROM ${REGISTRY}/library/alpine:${ALPINE_VER} AS release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=appuser /home/appuser /home/appuser
@@ -34,7 +34,7 @@ LABEL maintainer="" \
       org.opencontainers.image.title="version-bump" \
       org.opencontainers.image.description=""
 
-FROM scratch as release-scratch
+FROM scratch AS release-scratch
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=appuser /home/appuser /home/appuser

--- a/Dockerfile.buildkit
+++ b/Dockerfile.buildkit
@@ -2,7 +2,7 @@ ARG REGISTRY=docker.io
 ARG ALPINE_VER=3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
 ARG GO_VER=1.22.5-alpine@sha256:0d3653dd6f35159ec6e3d10263a42372f6f194c3dea0b35235d72aabde86486e
 
-FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} as build
+FROM --platform=$BUILDPLATFORM ${REGISTRY}/library/golang:${GO_VER} AS build
 RUN apk add --no-cache \
       ca-certificates \
       make
@@ -16,10 +16,10 @@ RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
 USER appuser
 CMD [ "bin/version-bump" ]
 
-FROM scratch as artifact
+FROM scratch AS artifact
 COPY --from=build /src/bin/version-bump /version-bump
 
-FROM ${REGISTRY}/library/alpine:${ALPINE_VER} as release-alpine
+FROM ${REGISTRY}/library/alpine:${ALPINE_VER} AS release-alpine
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=appuser /home/appuser /home/appuser
@@ -37,7 +37,7 @@ LABEL maintainer="" \
       org.opencontainers.image.title="version-bump" \
       org.opencontainers.image.description=""
 
-FROM scratch as release-scratch
+FROM scratch AS release-scratch
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build --chown=appuser /home/appuser /home/appuser


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Docker builds are outputting linter warnings because of the case of "as".
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Make the "FROM" and "AS" text the same case.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
make docker
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Chore: Fix Dockerfile linter warnings.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
