### PR TITLE
Feat: Prune unused entries in a lock file

### DIFF
--- a/internal/lockfile/lockfile_test.go
+++ b/internal/lockfile/lockfile_test.go
@@ -25,8 +25,8 @@ func TestLockfile(t *testing.T) {
 	if entry.Version != "123" {
 		t.Errorf("version mismatch, expected 123, received %s", entry.Version)
 	}
-	// write file
-	err = SaveFile(outFile, l)
+	// write file, including unused entries
+	err = l.SaveFile(outFile, false)
 	if err != nil {
 		t.Errorf("failed to save lockfile: %v", err)
 		return
@@ -44,5 +44,73 @@ func TestLockfile(t *testing.T) {
 	}
 	if !bytes.Equal(bIn, bOut) {
 		t.Errorf("output does not match input file %s:\n%s", inFile, bOut)
+	}
+	// add a new entry
+	err = l.Set("Test", "Z", "123")
+	if err != nil {
+		t.Errorf("failed to set Z: %v", err)
+	}
+	// overwrite same entry
+	err = l.Set("Test", "Z", "789")
+	if err != nil {
+		t.Errorf("failed to set Z: %v", err)
+	}
+	// write file, without unused entries
+	err = l.SaveFile(outFile, true)
+	if err != nil {
+		t.Errorf("failed to save lockfile: %v", err)
+		return
+	}
+	// read file of used entries
+	lUsed, err := LoadFile(outFile)
+	if err != nil {
+		t.Errorf("failed to load lockfile: %v", err)
+		return
+	}
+	// verify X is included but Y is missing
+	entry, err = lUsed.Get("Test", "X")
+	if err != nil {
+		t.Errorf("failed to get test/X entry: %v", err)
+		return
+	}
+	if entry.Version != "123" {
+		t.Errorf("version mismatch, expected 123, received %s", entry.Version)
+	}
+	entry, err = lUsed.Get("Test", "Z")
+	if err != nil {
+		t.Errorf("failed to get test/Z entry: %v", err)
+		return
+	}
+	if entry.Version != "789" {
+		t.Errorf("version mismatch, expected 789, received %s", entry.Version)
+	}
+	_, err = lUsed.Get("Test", "Y")
+	if err == nil {
+		t.Errorf("did not fail when reading an unused entry")
+	}
+}
+
+func TestNil(t *testing.T) {
+	var l *Locks
+	err := l.Set("A", "B", "C")
+	if err == nil {
+		t.Errorf("Set succeeded")
+	}
+	_, err = l.Get("A", "B")
+	if err == nil {
+		t.Errorf("Get succeeded")
+	}
+	err = l.Save(false)
+	if err == nil {
+		t.Errorf("Save succeeded")
+	}
+	err = l.SaveFile("./test.json", false)
+	if err == nil {
+		t.Errorf("SaveFile succeeded")
+	}
+	b := bytes.NewBuffer([]byte{})
+	err = l.SaveWriter(b, false)
+	if err == nil {
+		t.Errorf("SaveWriter succeeded")
 	}
 }


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

The entries in the lock file continuously grow if the key value periodically change.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

Prune unused entries in a lock file. This is only enabled by default when a file list is not given on the CLI.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

```shell
version-bump update
```
<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Feat: Prune unused entries in a lock file.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [X] Tests have been added or not applicable
- [X] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
