### PR TITLE
Fix: Handle nested templates in key field

### DIFF
--- a/internal/processor/processor.go
+++ b/internal/processor/processor.go
@@ -90,10 +90,12 @@ func (p *processor) getVer(curVer string, matchArgs map[string]string) (string, 
 	if err != nil {
 		return curVer, fmt.Errorf("failed to template args: processor=%v, %v", *p, err)
 	}
+	tdp.processor.Source = src
 	key, err := template.String(p.Processor.Key, tdp)
 	if err != nil {
 		return curVer, fmt.Errorf("failed to template key: processor=%v, %v", *p, err)
 	}
+	tdp.Processor.Key = key
 	// TODO: handle different options for source (read from current lock or real source)
 	results, err := source.Get(src)
 	if err != nil {

--- a/root.go
+++ b/root.go
@@ -182,8 +182,8 @@ func (cli *cliOpts) runAction(cmd *cobra.Command, args []string) error {
 	}
 	// display changes
 	for _, change := range changes {
-		fmt.Printf("Version changed: filename=%s, scan=%s, source=%s, key=%s, old=%s, new=%s\n",
-			change.Filename, change.Scan, change.Source, change.Key, change.Orig, change.New)
+		fmt.Printf("Version changed: filename=%s, processor=%s, key=%s, old=%s, new=%s\n",
+			change.Filename, change.Processor, change.Key, change.Orig, change.New)
 	}
 
 	if origDir != "." {


### PR DESCRIPTION
<!--

Commits must be signed indicating your agreement to the [DCO](https://developercertificate.org/).
See [DCO missing](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md) for steps to fix a missing signoff.

-->

### Fixes issue

Templates from other fields are not first expanded before processing the key field.
<!-- If this is a bug fix, include "fixes #xxxx", or "closes #xxxx" -->

### Describe the change

This handles nested templates in key field, and also adjusts the changes output to list the processor.
<!-- Include the type of change: bug fix, new feature, breaking change, documentation update -->
<!-- Describe what was changed, why the change was made, and how it was implemented -->

### How to verify it

<!-- Include steps that can be taken to verify the change -->

### Changelog text

- Fix: Handle nested templates in `key` field.
<!-- If the release changelog should have an entry for this, include it here -->

### Please verify and check that the pull request fulfills the following requirements

<!-- Mark the following with an [X] to verify they are included -->

- [ ] Tests have been added or not applicable
- [ ] Documentation has been added, updated, or not applicable
- [X] Changes have been rebased to main
- [X] Multiple commits to the same code have been squashed

<!-- markdownlint-disable-file MD041 -->
